### PR TITLE
Add X-Goog-Upload-Protocol header when uploading files for filenames to work

### DIFF
--- a/photos/upload.go
+++ b/photos/upload.go
@@ -86,6 +86,7 @@ func (p *Photos) UploadFile(ctx context.Context, filepath string) (*photoslibrar
 			return nil, fmt.Errorf("Could not create a request for uploading file %s: %s", filepath, err)
 		}
 		req.Header.Add("X-Goog-Upload-File-Name", filename)
+		req.Header.Add("X-Goog-Upload-Protocol", "raw")
 
 		p.log.Printf("Uploading %s", filepath)
 		res, err := p.client.Do(req)


### PR DESCRIPTION
Thanks for gpup @int128! It seems to be the only working way to properly more or less automate uploads to Google Photos uninteractively.

However, files uploaded with gpup do not keep their filenames and rather get renamed to YYYY-MM-DD.JPG/RW2 (you can see this in Picture info or if you have the option to show uploaded files in Google Drive).

It seems this was an issue with the API on Google's side (since the filename was sent as `X-Goog-Upload-File-Name` already) that was fixed on https://issuetracker.google.com/issues/79757390.
However it does not work unless you also send the `X-Goog-Upload-Protocol` with a `raw` value, which this PR adds.

This fixes the issue, however it seems to have the gotcha that images that were previously already uploaded with gpup without filenames will get duplicated when uploaded with filenames (maybe due to this different metadata). 
Haven't been able to test this behavior much, so open to suggestions on that front (maybe worth adding to the README/changelog, or having a flag to disable filename uploading?).