### PR TITLE
Improve HTTP debug log

### DIFF
--- a/cli/oauth2.go
+++ b/cli/oauth2.go
@@ -23,6 +23,11 @@ func (c *CLI) newClient(ctx context.Context) (*http.Client, error) {
 		Scopes:       photos.Scopes,
 		RedirectURL:  "http://localhost:8000",
 	}
+	if c.Debug {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
+			Transport: loggingTransport{http.DefaultTransport},
+		})
+	}
 	if token == nil {
 		flow := authz.AuthCodeFlow{
 			Config:     &oauth2Config,
@@ -48,7 +53,7 @@ func (c *CLI) newClient(ctx context.Context) (*http.Client, error) {
 		return nil, err
 	}
 	if c.Debug {
-		client = wrapLoggingClient(client)
+		client.Transport = loggingTransport{client.Transport}
 	}
 	return client, nil
 }


### PR DESCRIPTION
This changes format of HTTP debug log and adds OAuth HTTP log.

For example,

```
2018/09/14 09:55:19 [REQUEST] POST https://photoslibrary.googleapis.com/v1/uploads
POST /v1/uploads HTTP/1.1
Host: photoslibrary.googleapis.com
User-Agent: Go-http-client/1.1
Content-Length: 0
X-Goog-Upload-File-Name: ...
X-Goog-Upload-Protocol: raw
Accept-Encoding: gzip

2018/09/14 09:55:19 [REQUEST] POST https://accounts.google.com/o/oauth2/token
POST /o/oauth2/token HTTP/1.1
Host: accounts.google.com
User-Agent: Go-http-client/1.1
Content-Length: 229
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

2018/09/14 09:55:20 [RESPONSE] POST https://accounts.google.com/o/oauth2/token
HTTP/2.0 200 OK
Alt-Svc: quic=":443"; ma=2592000; v="44,43,39,35"
Cache-Control: private
Content-Type: application/json; charset=utf-8
Date: Fri, 14 Sep 2018 00:55:20 GMT
Server: ESF
Vary: Origin
Vary: X-Origin
Vary: Referer
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1; mode=block

2018/09/14 09:55:20 [REQUEST] POST https://photoslibrary.googleapis.com/v1/uploads
POST /v1/uploads HTTP/1.1
Host: photoslibrary.googleapis.com
User-Agent: Go-http-client/1.1
Content-Length: 0
Authorization: Bearer ...
X-Goog-Upload-File-Name: ...
X-Goog-Upload-Protocol: raw
Accept-Encoding: gzip
```
