### PR TITLE
Fix handling non 2xx response on fetch URL

### DIFF
--- a/photos/upload.go
+++ b/photos/upload.go
@@ -69,7 +69,11 @@ func (m *HTTPMediaItem) Open() (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("Downloading %s", m.Request.URL)
+	if r.StatusCode < 200 || r.StatusCode > 299 {
+		r.Body.Close()
+		return nil, fmt.Errorf("Got %s", r.Status)
+	}
+	log.Printf("%s %s", r.Status, m.Request.URL)
 	return r.Body, nil
 }
 


### PR DESCRIPTION
Non 2xx response should cause an error on fetching an URL. This fixes it.