### PR TITLE
Do not send Authorization header on fetch URLs

### DIFF
--- a/cli/upload.go
+++ b/cli/upload.go
@@ -16,11 +16,7 @@ func (c *CLI) upload(ctx context.Context) error {
 	if len(c.Paths) == 0 {
 		return fmt.Errorf("Nothing to upload")
 	}
-	client, err := c.newClient(ctx)
-	if err != nil {
-		return err
-	}
-	mediaItems, err := findMediaItems(c.Paths, client)
+	mediaItems, err := c.findMediaItems()
 	if err != nil {
 		return err
 	}
@@ -32,6 +28,10 @@ func (c *CLI) upload(ctx context.Context) error {
 		fmt.Printf("%3d: %s\n", i+1, mediaItem)
 	}
 
+	client, err := c.newOAuth2Client(ctx)
+	if err != nil {
+		return err
+	}
 	service, err := photos.New(client)
 	if err != nil {
 		return err
@@ -47,9 +47,10 @@ func (c *CLI) upload(ctx context.Context) error {
 	}
 }
 
-func findMediaItems(args []string, client *http.Client) ([]photos.MediaItem, error) {
+func (c *CLI) findMediaItems() ([]photos.MediaItem, error) {
+	client := c.newHTTPClient()
 	mediaItems := make([]photos.MediaItem, 0)
-	for _, arg := range args {
+	for _, arg := range c.Paths {
 		switch {
 		case strings.HasPrefix(arg, "http://") || strings.HasPrefix(arg, "https://"):
 			r, err := http.NewRequest("GET", arg, nil)

--- a/cli/upload_test.go
+++ b/cli/upload_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"io/ioutil"
-	"net/http"
 	"os"
 	"testing"
 )
@@ -39,7 +38,8 @@ func TestFindMediaItems(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	files, err := findMediaItems([]string{"."}, http.DefaultClient)
+	c := CLI{Paths: []string{"."}}
+	files, err := c.findMediaItems()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
#11 sends an `Authorization` header on fetching URLs and it exposes a token to others. This fixes the security issue.