### PR TITLE
Add header and basic auth support on fetch URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,18 +86,20 @@ Usage:
   gpup [OPTIONS] <FILE | DIRECTORY | URL>...
 
 Application Options:
-  -a, --album=TITLE              Add files to the album or a new album if it does not exist
-  -n, --new-album=TITLE          Add files to a new album
-      --gpupconfig=              Path to the config file (default: ~/.gpupconfig) [$GPUPCONFIG]
-      --debug                    Enable request and response logging [$DEBUG]
+  -a, --album=TITLE                 Add files to the album or a new album if it does not exist
+  -n, --new-album=TITLE             Add files to a new album
+      --request-header=KEY:VALUE    Add the header on fetching URLs
+      --request-auth=USER:PASS      Add the basic auth header on fetching URLs
+      --gpupconfig=                 Path to the config file (default: ~/.gpupconfig) [$GPUPCONFIG]
+      --debug                       Enable request and response logging [$DEBUG]
 
 Options read from gpupconfig:
-      --google-client-id=        Google API client ID [$GOOGLE_CLIENT_ID]
-      --google-client-secret=    Google API client secret [$GOOGLE_CLIENT_SECRET]
-      --google-token=            Google API token [$GOOGLE_TOKEN]
+      --google-client-id=           Google API client ID [$GOOGLE_CLIENT_ID]
+      --google-client-secret=       Google API client secret [$GOOGLE_CLIENT_SECRET]
+      --google-token=               Google API token [$GOOGLE_TOKEN]
 
 Help Options:
-  -h, --help                     Show this help message
+  -h, --help                        Show this help message
 ```
 
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -10,8 +10,10 @@ import (
 
 // CLI represents input for the command.
 type CLI struct {
-	AlbumTitle string `short:"a" long:"album" value-name:"TITLE" description:"Add files to the album or a new album if it does not exist"`
-	NewAlbum   string `short:"n" long:"new-album" value-name:"TITLE" description:"Add files to a new album"`
+	AlbumTitle       string   `short:"a" long:"album" value-name:"TITLE" description:"Add files to the album or a new album if it does not exist"`
+	NewAlbum         string   `short:"n" long:"new-album" value-name:"TITLE" description:"Add files to a new album"`
+	RequestHeaders   []string `long:"request-header" value-name:"KEY:VALUE" description:"Add the header on fetching URLs"`
+	RequestBasicAuth string   `long:"request-auth" value-name:"USER:PASS" description:"Add the basic auth header on fetching URLs"`
 
 	ConfigName string `long:"gpupconfig" env:"GPUPCONFIG" default:"~/.gpupconfig" description:"Path to the config file"`
 	Debug      bool   `long:"debug" env:"DEBUG" description:"Enable request and response logging"`

--- a/cli/upload.go
+++ b/cli/upload.go
@@ -57,6 +57,14 @@ func (c *CLI) findMediaItems() ([]photos.MediaItem, error) {
 			if err != nil {
 				return nil, fmt.Errorf("Could not parse URL: %s", err)
 			}
+			if c.RequestBasicAuth != "" {
+				kv := strings.SplitN(c.RequestBasicAuth, ":", 2)
+				r.SetBasicAuth(kv[0], kv[1])
+			}
+			for _, header := range c.RequestHeaders {
+				kv := strings.SplitN(header, ":", 2)
+				r.Header.Add(strings.TrimSpace(kv[0]), strings.TrimSpace(kv[1]))
+			}
 			mediaItems = append(mediaItems, &photos.HTTPMediaItem{
 				Client:  client,
 				Request: r,

--- a/cli/upload_test.go
+++ b/cli/upload_test.go
@@ -4,49 +4,92 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/int128/gpup/photos"
 )
 
-func TestFindMediaItems(t *testing.T) {
-	expects := []string{
-		"album1/a.jpg",
-		"album2/b.jpg",
-		"album2/c.jpg",
-	}
-
+func TestCLI_findMediaItems(t *testing.T) {
 	tempdir, err := ioutil.TempDir("", "FindFiles")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tempdir)
-	if err := os.Mkdir(tempdir+"/album1", 0755); err != nil {
+	if err := os.Chdir(tempdir); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(tempdir+"/album1/a.jpg", []byte{}, 0644); err != nil {
+	if err := os.Mkdir("album1", 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(tempdir+"/album2", 0755); err != nil {
+	if err := ioutil.WriteFile("album1/a.jpg", []byte{}, 0644); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(tempdir+"/album2/b.jpg", []byte{}, 0644); err != nil {
+	if err := os.Mkdir("album2", 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(tempdir+"/album2/c.jpg", []byte{}, 0644); err != nil {
+	if err := ioutil.WriteFile("album2/b.jpg", []byte{}, 0644); err != nil {
 		t.Fatal(err)
 	}
-	os.Chdir(tempdir)
+	if err := ioutil.WriteFile("album2/c.jpg", []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+	c := CLI{
+		Paths: []string{
+			".",
+			"http://www.example.com/image.jpg",
+		},
+	}
+	mediaItems, err := c.findMediaItems()
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	c := CLI{Paths: []string{"."}}
-	files, err := c.findMediaItems()
-	if err != nil {
-		t.Fatal(err)
+	if len(mediaItems) != 4 {
+		t.Errorf("wants size 4 but %d", len(mediaItems))
 	}
-
+	expects := []string{
+		"album1/a.jpg",
+		"album2/b.jpg",
+		"album2/c.jpg",
+	}
 	for i, expect := range expects {
-		if files[i].String() != expect {
-			t.Errorf("files[%d] wants %s but %s", i, expect, files[0])
+		if mediaItems[i].String() != expect {
+			t.Errorf("[%d] wants %s but %+v", i, expect, mediaItems[i])
 		}
+	}
+	if mediaItem, ok := mediaItems[3].(*photos.HTTPMediaItem); !ok {
+		t.Errorf("[3] wants HTTPMediaItem but %+v", mediaItems[3])
+	} else if r := mediaItem.Request; r == nil {
+		t.Errorf("[3].Request wants non-nil but nil")
+	} else if want := "http://www.example.com/image.jpg"; r.URL.String() != want {
+		t.Errorf("[3].Request.URL wants %s but %s", want, r.URL)
+	}
+}
+
+func TestCLI_findMediaItems_Headers(t *testing.T) {
+	c := CLI{
+		Paths:            []string{"http://www.example.com/image.jpg"},
+		RequestHeaders:   []string{"Cookie: foo"},
+		RequestBasicAuth: "alice:bob",
+	}
+	mediaItems, err := c.findMediaItems()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mediaItems) != 1 {
+		t.Errorf("wants size 1 but %d", len(mediaItems))
+	}
+	if mediaItem, ok := mediaItems[0].(*photos.HTTPMediaItem); !ok {
+		t.Errorf("[0] wants HTTPMediaItem but %+v", mediaItems[0])
+	} else if r := mediaItem.Request; r == nil {
+		t.Errorf("[0].Request wants non-nil but nil")
+	} else if r.URL.String() != "http://www.example.com/image.jpg" {
+		t.Errorf("[0].Request.URL wants %s but %s", "http://www.example.com/image.jpg", r.URL)
+	} else if v := r.Header.Get("Cookie"); v != "foo" {
+		t.Errorf("[0].Header(Cookie) wants foo but %s", v)
+	} else if username, password, ok := r.BasicAuth(); !ok {
+		t.Errorf("[0].BasicAuth wants ok but not")
+	} else if username != "alice" {
+		t.Errorf("[0].BasicAuth.username wants alice but %s", username)
+	} else if password != "bob" {
+		t.Errorf("[0].BasicAuth.password wants bob but %s", password)
 	}
 }


### PR DESCRIPTION
```
% go run main.go --debug --request-header=x-foo:bar --request-header=x-foo:baz --request-auth=alice:bob https://www.example.com/image.jpg
2018/09/17 03:15:05 The following 1 items will be uploaded:
  1: https://www.example.com/image.jpg
2018/09/17 03:15:05 Using token in ~/.gpupconfig
2018/09/17 03:15:05 Queued 1 item(s)
2018/09/17 03:15:05 [REQUEST] GET https://www.example.com/image.jpg
GET /image.jpg HTTP/1.1
Host: www.example.com
User-Agent: Go-http-client/1.1
Authorization: Basic YWxpY2U6Ym9i
X-Foo: bar
X-Foo: baz
Accept-Encoding: gzip

2018/09/17 03:15:06 [RESPONSE] GET https://www.example.com/image.jpg
HTTP/2.0 404 Not Found
```