### PR TITLE
Read files from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ You can specify URLs as well.
 gpup https://www.example.com/image.jpg
 ```
 
+You can also read files from stdin by specifying `-` as the path.
+
+```sh
+cat list_of_files | gpup -
+```
+
 ### Upload files to an album
 
 You can upload files to the album by `-a` option.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -15,6 +15,10 @@ type CLI struct {
 	RequestHeaders   []string `long:"request-header" value-name:"KEY:VALUE" description:"Add the header on fetching URLs"`
 	RequestBasicAuth string   `long:"request-auth" value-name:"USER:PASS" description:"Add the basic auth header on fetching URLs"`
 
+	ExcludePattern   string   `long:"exc" value-name:"PATTERN" description:"Regex pattern describing files to exclude"`
+	IncludePattern   string   `long:"inc" value-name:"PATTERN" description:"Regex pattern describing files to include (inclusion overridden by explicit exclusion via --exc)"`
+
+
 	ConfigName string `long:"gpupconfig" env:"GPUPCONFIG" default:"~/.gpupconfig" description:"Path to the config file"`
 	Debug      bool   `long:"debug" env:"DEBUG" description:"Enable request and response logging"`
 


### PR DESCRIPTION
Added ability to read a file list from stdin when provided a path of '-'.

I did this because I had various image files that needed uploading (and putting into albums) but didn't necessarily line up with directories. Of course it's possible to do this already with an invocation of gpup per-image, however this loses parallel uploads (and would also hit the API rate-limit in my case).

(Note this is built on top of the previous include/exclude commit I already created a PR for.)