### PR TITLE
Add support for Raspbery Pi 3 processors

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,14 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm
+    goarm:
+      - 7
+    ignore:
+      - goos: windows
+        goarch: arm
+      - goos: darwin
+        goarch: arm
 archive:
   files:
     - none*


### PR DESCRIPTION
I've added ARM support in GoReleaser:
```
 • BUILDING BINARIES
      • building                  binary=dist/darwin_amd64/gpup
      • building                  binary=dist/linux_amd64/gpup
      • building                  binary=dist/linux_arm_7/gpup
      • building                  binary=dist/windows_amd64/gpup.exe
   • ARCHIVES         
      • creating                  archive=dist/gpup_1.6_darwin_amd64.tar.gz
      • creating                  archive=dist/gpup_1.6_linux_amd64.tar.gz
      • creating                  archive=dist/gpup_1.6_linux_armv7.tar.gz
      • creating                  archive=dist/gpup_1.6_windows_amd64.tar.gz
```
Signed-off-by: pacoorozco <paco@pacoorozco.info>

Closes: #34 