### PR TITLE
Fix deprecated section in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
         goarch: arm
       - goos: darwin
         goarch: arm
-archive:
+archives:
   files:
     - none*
 brew:


### PR DESCRIPTION
Fix deprecated `archive` section in goreleaser, see [deprecation notice](https://goreleaser.com/deprecations/#archive). 

Signed-off-by: pacoorozco <paco@pacoorozco.info>